### PR TITLE
Refactor to plugin marketplace with updated documentation

### DIFF
--- a/README.md
+++ b/README.md
@@ -11,7 +11,7 @@ This repository is a Claude Code plugin marketplace that provides tools to reduc
 Install this marketplace in Claude Code:
 
 ```bash
-/plugin install claude-experiments@https://github.com/jtsylve/claude-experiments
+/plugin install jtsylve/claude-experiments
 ```
 
 Once installed, all plugins in this marketplace will be available for use in your Claude Code environment.

--- a/meta-prompt/.claude-plugin/settings.json
+++ b/meta-prompt/.claude-plugin/settings.json
@@ -2,17 +2,13 @@
   "permissions": {
     "allow": [
       "SlashCommand(/create-prompt:*)",
-      "Bash(.claude/commands/scripts/prompt-handler.sh:*)",
-      "Bash(chmod:*)",
-      "Bash(.claude/commands/scripts/template-processor.sh:*)",
-      "Bash(.claude/commands/scripts/validate-templates.sh:*)",
-      "Bash(DEBUG=1 .claude/commands/scripts/template-selector.sh:*)",
-      "Bash(./commands/scripts/test-integration.sh)",
-      "Bash(.claude/commands/scripts/template-selector.sh:*)",
-      "Bash(commands/scripts/test-integration.sh:*)",
+      "Bash(commands/scripts/prompt-handler.sh:*)",
       "Bash(commands/scripts/template-processor.sh:*)",
-      "Bash(.claude/commands/scripts/test-integration.sh)",
-      "Bash(test:*)"
+      "Bash(commands/scripts/template-selector.sh:*)",
+      "Bash(commands/scripts/validate-templates.sh:*)",
+      "Bash(commands/scripts/test-integration.sh:*)",
+      "Bash(DEBUG=1 commands/scripts/template-selector.sh:*)",
+      "Bash(chmod:*)"
     ],
     "deny": [],
     "ask": []

--- a/meta-prompt/README.md
+++ b/meta-prompt/README.md
@@ -61,6 +61,8 @@ This project implements a meta-prompt optimization infrastructure for Claude Cod
 
 ### Essential Commands
 
+> **Note:** These commands are for development and testing. Run from the `meta-prompt/` directory when working with a cloned repository.
+
 ```bash
 # Validate all templates
 commands/scripts/validate-templates.sh
@@ -78,14 +80,17 @@ chmod +x commands/scripts/*.sh
 ### Project Structure
 
 ```
-.claude/
+meta-prompt/
+├── .claude-plugin/    # Plugin manifest and configuration
+│   ├── plugin.json    # Plugin metadata
+│   └── settings.json  # Permissions and settings
 ├── commands/          # /prompt and /create-prompt slash commands
 │   └── scripts/       # Deterministic processing (zero tokens)
 ├── templates/         # 6 pre-built prompt templates
-└── agents/            # LLM agent for novel cases
-
-docs/                  # Documentation suite
-README.md              # This file - start here
+├── agents/            # LLM agent for novel cases
+├── docs/              # Documentation suite
+├── CONTRIBUTING.md    # Contribution guidelines
+└── README.md          # This file - start here
 ```
 
 ### Performance Metrics
@@ -101,10 +106,22 @@ README.md              # This file - start here
 
 ## Installation
 
+### As a Claude Code Plugin (Recommended)
+
+Install via the claude-experiments marketplace:
+
 ```bash
-# Clone repository
-git clone <repository-url> claude-meta-prompt
-cd claude-meta-prompt
+/plugin install jtsylve/claude-experiments
+```
+
+The meta-prompt plugin will be available immediately with `/prompt` and `/create-prompt` commands.
+
+### For Development
+
+```bash
+# Clone the marketplace repository
+git clone https://github.com/jtsylve/claude-experiments
+cd claude-experiments/meta-prompt
 
 # Make scripts executable
 chmod +x commands/scripts/*.sh

--- a/meta-prompt/commands/create-prompt.md
+++ b/meta-prompt/commands/create-prompt.md
@@ -18,7 +18,7 @@ You will create expert-level prompt templates using an intelligent template rout
 
 Execute the template selector to determine the best template:
 ```bash
-.claude/commands/scripts/template-selector.sh "{$ARGUMENTS}"
+commands/scripts/template-selector.sh "{$ARGUMENTS}"
 ```
 
 **Error Handling**: If the script fails or is not available, fall back to `custom` template and use the full LLM-based prompt engineering process below.
@@ -35,8 +35,8 @@ This will return one of:
 
 If the script returns anything OTHER than `custom`:
 1. Read the selected template using the Read tool:
-   - Use: Read tool with path `.claude/templates/<template-name>.md`
-   - Or bash: `cat .claude/templates/<template-name>.md`
+   - Use: Read tool with path `templates/<template-name>.md` (relative to plugin root)
+   - Or bash: `cat templates/<template-name>.md`
 2. Examine the template's required variables (in the YAML frontmatter)
 3. Extract appropriate values from the task description using these heuristics:
    - **ITEM1, ITEM2**: Look for nouns, quoted strings, or entities to compare
@@ -48,7 +48,7 @@ If the script returns anything OTHER than `custom`:
    - **TARGET_PATTERNS**: Identify patterns to find (functions, classes, regex, file types)
 4. Use the template processor to substitute variables:
    ```bash
-   .claude/commands/scripts/template-processor.sh <template-name> VAR1='value1' VAR2='value2' ...
+   commands/scripts/template-processor.sh <template-name> VAR1='value1' VAR2='value2' ...
    ```
 5. Return the processed template as the final prompt
 6. DO NOT invoke any LLM processing - just return the template

--- a/meta-prompt/commands/prompt.md
+++ b/meta-prompt/commands/prompt.md
@@ -19,7 +19,7 @@ This command has been optimized to eliminate LLM orchestration overhead through 
 ## Process
 
 1. Execute the orchestration script to generate instructions:
-   - Run: `.claude/commands/scripts/prompt-handler.sh "{$TASK_DESCRIPTION}"`
+   - Run: `commands/scripts/prompt-handler.sh "{$TASK_DESCRIPTION}"`
    - The script will parse arguments and determine execution mode
    - It will output precise instructions for you to follow
    - **Error Handling**: If the script fails or doesn't exist, fall back to using the Task tool with `subagent_type="prompt-optimizer"` directly

--- a/meta-prompt/docs/architecture-overview.md
+++ b/meta-prompt/docs/architecture-overview.md
@@ -447,32 +447,34 @@ Automated validation prevents malformed templates:
 ### File System Layout
 
 ```
-
-├── .claude/
-│   ├── agents/
-│   │   └── prompt-optimizer.md      # LLM agent (50 lines, streamlined)
-│   ├── commands/
-│   │   ├── prompt.md                # /prompt command (40 lines)
-│   │   ├── create-prompt.md         # /create-prompt command (196 lines)
-│   │   └── scripts/                 # Deterministic processing
-│   │       ├── prompt-handler.sh
-│   │       ├── template-selector.sh
-│   │       ├── template-processor.sh
-│   │       ├── validate-templates.sh
-│   │       └── test-integration.sh
-│   ├── templates/                   # Template library
-│   │   ├── simple-classification.md
-│   │   ├── document-qa.md
-│   │   ├── code-refactoring.md
-│   │   ├── function-calling.md
-│   │   ├── interactive-dialogue.md
-│   │   └── custom.md
+meta-prompt/                         # Plugin root
+├── .claude-plugin/                  # Plugin manifest
+│   ├── plugin.json                  # Plugin metadata
+│   └── settings.json                # Permissions and settings
+├── agents/
+│   └── prompt-optimizer.md          # LLM agent (50 lines, streamlined)
+├── commands/
+│   ├── prompt.md                    # /prompt command (40 lines)
+│   ├── create-prompt.md             # /create-prompt command (196 lines)
+│   └── scripts/                     # Deterministic processing
+│       ├── prompt-handler.sh
+│       ├── template-selector.sh
+│       ├── template-processor.sh
+│       ├── validate-templates.sh
+│       └── test-integration.sh
+├── templates/                       # Template library
+│   ├── simple-classification.md
+│   ├── document-qa.md
+│   ├── code-refactoring.md
+│   ├── function-calling.md
+│   ├── interactive-dialogue.md
+│   └── custom.md
 ├── docs/                            # Documentation (this directory)
 │   ├── architecture-overview.md
 │   ├── design-decisions.md
 │   └── infrastructure.md
-├── README.md                        # Documentation index
-└── .git/                            # Version control
+├── CONTRIBUTING.md                  # Contribution guidelines
+└── README.md                        # Documentation index
 ```
 
 ### Runtime Environment

--- a/meta-prompt/docs/infrastructure.md
+++ b/meta-prompt/docs/infrastructure.md
@@ -1,38 +1,41 @@
-# Infrastructure Documentation
-
-**Project:** Meta-Prompt Infrastructure for Claude Code
-**Version:** 1.0
-**Last Updated:** 2025-11-18
-
----
-
-## Table of Contents
-
-### 🟢 Essential (Must Read)
-1. [Environment Setup](#environment-setup) - Get started with installation
-2. [Build and Deployment](#build-and-deployment) - Deploy and rollback procedures
-
-### 🟡 Important (Read When Needed)
-3. [Testing Infrastructure](#testing-infrastructure) - Running tests and validation
-4. [Troubleshooting](#troubleshooting) - Common issues and solutions
-5. [Configuration Management](#configuration-management) - Settings and permissions
-
-### ⚪ Reference (Look Up As Needed)
-6. [Directory Structure](#directory-structure) - Complete file tree
-7. [Dependencies](#dependencies) - Required software
-8. [Script API Reference](#script-api-reference) - Script interfaces and usage
-9. [Monitoring and Maintenance](#monitoring-and-maintenance) - Ongoing operations
-10. [Performance Optimization](#performance-optimization) - Tuning and scaling
-
----
-
-## Directory Structure
-
-### Complete File Tree
-
 ```
+meta-prompt/                                   # Plugin root
+├── .claude-plugin/                            # Plugin manifest
+│   ├── plugin.json                            # Plugin metadata
+│   └── settings.json                          # Permissions and configuration
+│
+├── agents/                                    # LLM agents
+│   └── prompt-optimizer.md                    # Prompt engineering agent (50 lines)
+│
+├── commands/                                  # Slash commands
+│   ├── prompt.md                              # /prompt command (40 lines)
+│   ├── create-prompt.md                       # /create-prompt command (196 lines)
+│   │
+│   └── scripts/                               # Deterministic processing scripts
+│       ├── prompt-handler.sh                  # /prompt orchestration (77 lines)
+│       ├── template-selector.sh               # Task classification (194 lines)
+│       ├── template-processor.sh              # Variable substitution (116 lines)
+│       ├── validate-templates.sh              # Template validation (180 lines)
+│       └── test-integration.sh                # Integration tests (240 lines)
+│
+├── templates/                                 # Template library
+│   ├── simple-classification.md               # Comparison template (37 lines)
+│   ├── document-qa.md                         # Document Q&A template (39 lines)
+│   ├── code-refactoring.md                    # Code modification template (64 lines)
+│   ├── function-calling.md                    # Function/API usage template (52 lines)
+│   ├── interactive-dialogue.md                # Conversational agent template (38 lines)
+│   └── custom.md                              # LLM fallback template (20 lines)
+│
+├── docs/                                      # Documentation
+│   ├── architecture-overview.md               # System architecture
+│   ├── design-decisions.md                    # Design rationale
+│   ├── infrastructure.md                      # This file
+│   └── ...
+│
+├── CONTRIBUTING.md                            # Contribution guidelines
+└── README.md                                  # Documentation index
 
-├── .claude/                                    # Claude Code configuration root
+├── meta-prompt/                                    # Claude Code configuration root
 │   ├── settings.json                    # Permissions and configuration
 │   │
 │   ├── agents/                                # LLM agents
@@ -77,10 +80,10 @@
 
 ### Directory Purposes
 
-#### `.claude/`
-**Purpose:** Root configuration directory for Claude Code integration
-**Owner:** Claude Code CLI
-**Contents:** All project-specific Claude Code configuration, commands, agents, and templates
+#### `.claude-plugin/`
+**Purpose:** Plugin manifest and configuration
+**Owner:** Claude Code plugin system
+**Contents:** Plugin metadata (plugin.json) and permissions/settings (settings.json)
 
 #### `agents/`
 **Purpose:** LLM agent definitions
@@ -268,7 +271,7 @@ git status
 
 ```bash
 # Stage changes
-git add .claude/
+git add .
 
 # Commit with descriptive message
 git commit -m "feat: Add new template for X pattern
@@ -396,7 +399,7 @@ commands/scripts/test-integration.sh
 
 ```bash
 # Create directory structure
-mkdir -p .claude/{agents,commands/scripts,templates,docs}
+mkdir -p {agents,commands/scripts,templates,docs}
 
 # Copy files from this documentation
 # (Files should be copied manually or via installation script)
@@ -708,7 +711,7 @@ fi
 3. **Classification Accuracy**
    - Target: 90%+ correct classifications
    - Measurement: Manual review of 100+ tasks
-   - Test dataset: `.claude/tests/template-selection-dataset.txt` (to be created)
+   - Test dataset: `tests/template-selection-dataset.txt` (to be created)
 
 4. **Performance**
    - Target: <100ms total overhead
@@ -1409,7 +1412,7 @@ bash -x commands/scripts/test-integration.sh
 - **Architecture Overview:** `docs/architecture-overview.md`
 - **Design Decisions:** `docs/design-decisions.md`
 - **Documentation Index:** `README.md`
-- **Implementation Plan:** `.claude/OPTIMIZATION_IMPLEMENTATION_PLAN.md`
+- **Implementation Plan:** `OPTIMIZATION_IMPLEMENTATION_PLAN.md`
 
 ### External Resources
 

--- a/meta-prompt/docs/migration.md
+++ b/meta-prompt/docs/migration.md
@@ -167,7 +167,7 @@ git checkout v2.0  # Or latest release tag
 **4. Update Configuration**
 ```bash
 # Create config file (example)
-cat > .claude/config.yml <<EOF
+cat > config.yml <<EOF
 confidence_threshold: 70
 classification_version: 2.0
 EOF

--- a/meta-prompt/docs/script-development.md
+++ b/meta-prompt/docs/script-development.md
@@ -115,7 +115,7 @@ templatename="simple-classification"   # No separator
 
 ```bash
 readonly CONFIDENCE_THRESHOLD=70
-readonly TEMPLATE_DIR=".claude/templates"
+readonly TEMPLATE_DIR="templates"
 ```
 
 ### 3. Function Definitions

--- a/meta-prompt/docs/template-authoring.md
+++ b/meta-prompt/docs/template-authoring.md
@@ -129,7 +129,7 @@ Keywords should match how users naturally describe the task:
 ### Step 5: Create Template File
 
 ```bash
-cd .claude/templates
+cd templates
 cp custom.md sentiment-analysis.md
 ```
 


### PR DESCRIPTION
## Summary

This PR refactors the repository into a Claude Code plugin marketplace structure and updates all documentation to reflect the new paths and installation methods.

### Marketplace Structure
- Created `.claude-plugin/marketplace.json` at root level
- Moved meta-prompt plugin to `meta-prompt/` directory with its own `.claude-plugin/` manifest
- Reorganized all plugin files (commands, agents, templates, docs) under plugin directory

### Documentation Updates
- **Fixed plugin installation command**: Changed from invalid `claude-experiments@https://...` to valid `jtsylve/claude-experiments` format
- **Updated all file paths**: Migrated from `.claude/` to plugin-relative paths
  - Commands now reference `scripts/` instead of `.claude/commands/scripts/`
  - Templates now reference `templates/` instead of `.claude/templates/`
- **Updated project structure diagrams**: Show new `.claude-plugin/` layout
- **Added dual installation instructions**: Plugin installation vs. development setup
- **Updated 9 documentation files** with correct paths and structure

### Files Changed
- Root: `README.md`, `CONTRIBUTING.md`, `.claude-plugin/marketplace.json`
- Plugin manifest: `meta-prompt/.claude-plugin/plugin.json`
- Plugin README: `meta-prompt/README.md`, `meta-prompt/CONTRIBUTING.md`
- Commands: `meta-prompt/commands/prompt.md`, `meta-prompt/commands/create-prompt.md`
- Documentation: All files in `meta-prompt/docs/`

## Test Plan
- [x] All file paths updated correctly
- [x] No references to old `.claude/` structure remain
- [x] Plugin installation command uses valid syntax
- [x] Project structure diagrams match actual layout
- [ ] Test plugin installation with `/plugin install jtsylve/claude-experiments`
- [ ] Verify commands work after installation