### PR TITLE
Remove model specifications from front matter

### DIFF
--- a/meta-prompt/agents/prompt-optimizer.md
+++ b/meta-prompt/agents/prompt-optimizer.md
@@ -1,7 +1,6 @@
 ---
 name: prompt-optimizer
 description: Expert prompt engineer for novel tasks, template refinement, and complex multi-agent workflows
-model: claude-sonnet-4-5-20250929
 allowed-tools: [SlashCommand, Task, AskUserQuestion]
 ---
 

--- a/meta-prompt/commands/create-prompt.md
+++ b/meta-prompt/commands/create-prompt.md
@@ -2,7 +2,6 @@
 name: create-prompt
 description: Create expert-level prompt templates for Claude Code with best practices, examples, and structured output
 argument-hint: <task description>
-model: claude-sonnet-4-5-20250929
 allowed-tools: [Bash, Read]
 ---
 

--- a/meta-prompt/commands/prompt.md
+++ b/meta-prompt/commands/prompt.md
@@ -2,7 +2,6 @@
 name: prompt
 description: Optimize a prompt and optionally execute it in a fresh context
 argument-hint: <task or prompt to optimize> [--return-only]
-model: claude-sonnet-4-5-20250929
 allowed-tools: [Task, Bash]
 ---
 


### PR DESCRIPTION
Model specifications in the front matter are not portable across different environments and configurations. Removed the model field from:
- meta-prompt/commands/create-prompt.md
- meta-prompt/commands/prompt.md
- meta-prompt/agents/prompt-optimizer.md