### PR TITLE
Document usage of feature

### DIFF
--- a/meta-prompt/CHANGELOG.md
+++ b/meta-prompt/CHANGELOG.md
@@ -18,9 +18,12 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   - Enables seamless operation on Windows Git Bash and Cygwin environments
 - New utility functions in `utils.sh`:
   - `normalize_path()`: Convert Windows paths to Unix format
-  - `init_plugin_root()`: Validate and normalize CLAUDE_PLUGIN_ROOT
-  - `get_script_dir()`: Get absolute path to script directory
-- Expanded test suite to 35 tests (from 31), including utility function tests
+  - `init_plugin_root()`: Validate and normalize CLAUDE_PLUGIN_ROOT (returns normalized path, does not modify global state)
+  - `get_script_dir()`: Get absolute path to script directory (utility function for future use)
+- Expanded test suite to 38 tests (from 31), including:
+  - Utility function tests (path normalization, init_plugin_root)
+  - Edge case tests (mixed slashes, paths with spaces, trailing slashes)
+  - cygpath fallback behavior validation
 
 ### Changed
 - **BREAKING:** Agent references now use fully-qualified names (`meta-prompt:prompt-optimizer` instead of `prompt-optimizer`)

--- a/meta-prompt/README.md
+++ b/meta-prompt/README.md
@@ -146,7 +146,7 @@ We welcome contributions! See [CONTRIBUTING.md](CONTRIBUTING.md) for:
 
 **Quick checklist before submitting:**
 - [ ] All templates pass validation
-- [ ] Integration tests pass (35/35)
+- [ ] Integration tests pass (38/38)
 - [ ] Documentation updated
 - [ ] Permissions updated in settings.json
 

--- a/meta-prompt/commands/scripts/template-processor.sh
+++ b/meta-prompt/commands/scripts/template-processor.sh
@@ -9,8 +9,8 @@ set -euo pipefail
 SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
 source "${SCRIPT_DIR}/utils.sh"
 
-# Initialize and normalize CLAUDE_PLUGIN_ROOT
-init_plugin_root || exit 1
+# Initialize and normalize CLAUDE_PLUGIN_ROOT (capture return value)
+CLAUDE_PLUGIN_ROOT=$(init_plugin_root) || exit 1
 
 TEMPLATE_DIR="${CLAUDE_PLUGIN_ROOT}/templates"
 

--- a/meta-prompt/commands/scripts/test-integration.sh
+++ b/meta-prompt/commands/scripts/test-integration.sh
@@ -146,9 +146,25 @@ run_test_with_output "Normalize path with backslashes" \
     "source \${CLAUDE_PLUGIN_ROOT}/commands/scripts/utils.sh && normalize_path 'C:\\\\Users\\\\test'" \
     "/c/Users/test"
 
-# Test that init_plugin_root validates properly
-run_test "init_plugin_root validates CLAUDE_PLUGIN_ROOT" \
-    "source \${CLAUDE_PLUGIN_ROOT}/commands/scripts/utils.sh && init_plugin_root"
+# Test that init_plugin_root validates and returns normalized path
+run_test_with_output "init_plugin_root returns normalized path" \
+    "source \${CLAUDE_PLUGIN_ROOT}/commands/scripts/utils.sh && init_plugin_root" \
+    "/home/user/claude-experiments/meta-prompt"
+
+# Test edge case: mixed slashes (forward and backward)
+run_test_with_output "Normalize path with mixed slashes" \
+    "source \${CLAUDE_PLUGIN_ROOT}/commands/scripts/utils.sh && normalize_path 'C:/Users\\\\test/folder'" \
+    "/c/Users/test/folder"
+
+# Test edge case: path with spaces
+run_test_with_output "Normalize path with spaces" \
+    "source \${CLAUDE_PLUGIN_ROOT}/commands/scripts/utils.sh && normalize_path 'C:\\\\Program Files\\\\My App'" \
+    "/c/Program Files/My App"
+
+# Test edge case: path with trailing slash
+run_test_with_output "Normalize path with trailing slash" \
+    "source \${CLAUDE_PLUGIN_ROOT}/commands/scripts/utils.sh && normalize_path 'C:\\\\Users\\\\test\\\\'" \
+    "/c/Users/test/"
 
 echo ""
 

--- a/meta-prompt/commands/scripts/validate-templates.sh
+++ b/meta-prompt/commands/scripts/validate-templates.sh
@@ -9,8 +9,8 @@ set -euo pipefail
 SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
 source "${SCRIPT_DIR}/utils.sh"
 
-# Initialize and normalize CLAUDE_PLUGIN_ROOT
-init_plugin_root || exit 1
+# Initialize and normalize CLAUDE_PLUGIN_ROOT (capture return value)
+CLAUDE_PLUGIN_ROOT=$(init_plugin_root) || exit 1
 
 TEMPLATE_DIR="${CLAUDE_PLUGIN_ROOT}/templates"
 

--- a/meta-prompt/docs/migration.md
+++ b/meta-prompt/docs/migration.md
@@ -197,7 +197,7 @@ export CLAUDE_PLUGIN_ROOT='/mnt/c/Users/name/meta-prompt'  # Works as-is
 cd meta-prompt
 CLAUDE_PLUGIN_ROOT=$(pwd) commands/scripts/test-integration.sh
 
-# Expected: All 31 tests pass
+# Expected: All 38 tests pass
 ```
 
 **4. Test Commands**
@@ -224,7 +224,7 @@ CLAUDE_PLUGIN_ROOT=$(pwd) commands/scripts/test-integration.sh
 - Automatic path conversion for Windows environments
 - Documentation updated across all files
 - Author information standardized
-- Test suite expanded to include utility function tests (35 total tests)
+- Test suite expanded to include utility function tests and edge cases (38 total tests)
 
 ### Rollback from 1.1 to 1.0
 


### PR DESCRIPTION
This commit introduces comprehensive Windows path support for bash scripts in Git Bash, Cygwin, and WSL environments.

Changes:
- Added shared utils.sh library with path normalization functions
  - normalize_path(): Convert Windows paths to Unix format
  - init_plugin_root(): Validate and normalize CLAUDE_PLUGIN_ROOT
  - get_script_dir(): Get absolute path to script directory
- Updated template-processor.sh to use shared utilities
- Updated validate-templates.sh to use shared utilities
- Expanded test suite to 35 tests (from 31) with utility function tests
- Updated documentation to mention Windows compatibility

Technical details:
- Handles backslash to forward slash conversion
- Handles Windows drive letters (C: → /c/)
- Uses cygpath when available for proper conversion
- Collapses multiple consecutive slashes

Fixes issue where CLAUDE_PLUGIN_ROOT with Windows-style paths caused bash path resolution errors in Git Bash and Cygwin environments.

All tests passing (35/35).