### PR TITLE
Normalize plugin directory path in prompts

### DIFF
--- a/meta-prompt/CHANGELOG.md
+++ b/meta-prompt/CHANGELOG.md
@@ -37,8 +37,13 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - All script paths updated to use `${CLAUDE_PLUGIN_ROOT}` environment variable instead of relative paths
   - Improves portability and reliability when scripts are invoked from different directories
   - Scripts will now fail fast with clear error messages if `CLAUDE_PLUGIN_ROOT` is not set
+- **Command prompts updated to normalize paths before using CLAUDE_PLUGIN_ROOT**
+  - `/prompt` and `/create-prompt` commands now normalize paths using `utils.sh` before invoking scripts
+  - Ensures Windows paths are converted to Unix format before being passed to bash scripts or tools
+  - Critical for cross-platform compatibility in Claude Code environment
 - Scripts now use shared `utils.sh` library for consistent path handling and environment validation
   - `template-processor.sh` and `validate-templates.sh` updated to use `init_plugin_root()`
+  - `test-integration.sh` updated to normalize CLAUDE_PLUGIN_ROOT at startup
   - Ensures consistent behavior across all scripts
 
 ### Fixed

--- a/meta-prompt/commands/create-prompt.md
+++ b/meta-prompt/commands/create-prompt.md
@@ -13,11 +13,18 @@ You will create expert-level prompt templates using an intelligent template rout
 
 ## Process
 
-**Step 1: Template Selection**
+**Step 1: Normalize Plugin Path**
+
+First, normalize the plugin path for cross-platform compatibility:
+```bash
+source ${CLAUDE_PLUGIN_ROOT}/commands/scripts/utils.sh && NORMALIZED_ROOT=$(normalize_path "${CLAUDE_PLUGIN_ROOT}")
+```
+
+**Step 2: Template Selection**
 
 Execute the template selector to determine the best template:
 ```bash
-${CLAUDE_PLUGIN_ROOT}/commands/scripts/template-selector.sh "{$ARGUMENTS}"
+${NORMALIZED_ROOT}/commands/scripts/template-selector.sh "{$ARGUMENTS}"
 ```
 
 **Error Handling**: If the script fails or is not available, fall back to `custom` template and use the full LLM-based prompt engineering process below.
@@ -30,12 +37,12 @@ This will return one of:
 - `simple-classification` - For comparison or classification tasks
 - `custom` - For novel tasks requiring LLM-based prompt engineering
 
-**Step 2: Route Based on Selection**
+**Step 3: Route Based on Selection**
 
 If the script returns anything OTHER than `custom`:
 1. Read the selected template using the Read tool:
-   - Use: Read tool with path `${CLAUDE_PLUGIN_ROOT}/templates/<template-name>.md`
-   - Or bash: `cat ${CLAUDE_PLUGIN_ROOT}/templates/<template-name>.md`
+   - Use: Read tool with path `${NORMALIZED_ROOT}/templates/<template-name>.md`
+   - Or bash: `cat ${NORMALIZED_ROOT}/templates/<template-name>.md`
 2. Examine the template's required variables (in the YAML frontmatter)
 3. Extract appropriate values from the task description using these heuristics:
    - **ITEM1, ITEM2**: Look for nouns, quoted strings, or entities to compare
@@ -47,7 +54,7 @@ If the script returns anything OTHER than `custom`:
    - **TARGET_PATTERNS**: Identify patterns to find (functions, classes, regex, file types)
 4. Use the template processor to substitute variables:
    ```bash
-   ${CLAUDE_PLUGIN_ROOT}/commands/scripts/template-processor.sh <template-name> VAR1='value1' VAR2='value2' ...
+   ${NORMALIZED_ROOT}/commands/scripts/template-processor.sh <template-name> VAR1='value1' VAR2='value2' ...
    ```
 5. Return the processed template as the final prompt
 6. DO NOT invoke any LLM processing - just return the template

--- a/meta-prompt/commands/prompt.md
+++ b/meta-prompt/commands/prompt.md
@@ -17,8 +17,9 @@ This command has been optimized to eliminate LLM orchestration overhead through 
 
 ## Process
 
-1. Execute the orchestration script to generate instructions:
-   - Run: `${CLAUDE_PLUGIN_ROOT}/commands/scripts/prompt-handler.sh "{$TASK_DESCRIPTION}"`
+1. Normalize the plugin path and execute the orchestration script to generate instructions:
+   - First normalize the path: `source ${CLAUDE_PLUGIN_ROOT}/commands/scripts/utils.sh && NORMALIZED_ROOT=$(normalize_path "${CLAUDE_PLUGIN_ROOT}")`
+   - Run: `${NORMALIZED_ROOT}/commands/scripts/prompt-handler.sh "{$TASK_DESCRIPTION}"`
    - The script will parse arguments and determine execution mode
    - It will output precise instructions for you to follow
    - **Error Handling**: If the script fails or doesn't exist, fall back to using the Task tool with `subagent_type="meta-prompt:prompt-optimizer"` directly

--- a/meta-prompt/commands/scripts/test-integration.sh
+++ b/meta-prompt/commands/scripts/test-integration.sh
@@ -4,6 +4,11 @@
 
 set -euo pipefail
 
+# Source utilities and normalize CLAUDE_PLUGIN_ROOT
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+source "${SCRIPT_DIR}/utils.sh"
+CLAUDE_PLUGIN_ROOT=$(init_plugin_root) || exit 1
+
 # ANSI colors
 GREEN='\033[0;32m'
 RED='\033[0;31m'
@@ -149,7 +154,7 @@ run_test_with_output "Normalize path with backslashes" \
 # Test that init_plugin_root validates and returns normalized path
 run_test_with_output "init_plugin_root returns normalized path" \
     "source \${CLAUDE_PLUGIN_ROOT}/commands/scripts/utils.sh && init_plugin_root" \
-    "/home/user/claude-experiments/meta-prompt"
+    "meta-prompt"
 
 # Test edge case: mixed slashes (forward and backward)
 run_test_with_output "Normalize path with mixed slashes" \

--- a/meta-prompt/docs/migration.md
+++ b/meta-prompt/docs/migration.md
@@ -174,10 +174,14 @@ export CLAUDE_PLUGIN_ROOT=/path/to/meta-prompt
 
 **Windows Path Handling:**
 
-All scripts now include automatic path normalization for Windows environments. The shared `utils.sh` library handles:
+All scripts and prompts now include automatic path normalization for Windows environments. The shared `utils.sh` library handles:
 - Converting backslashes to forward slashes
 - Converting Windows drive letters (C: → /c/)
 - Using `cygpath` when available (Git Bash, Cygwin)
+
+The normalization happens in two places:
+1. **Scripts**: Scripts that use `CLAUDE_PLUGIN_ROOT` call `init_plugin_root()` to normalize the path at startup
+2. **Prompts**: Command prompts (`/prompt`, `/create-prompt`) instruct Claude to normalize paths before invoking scripts
 
 This means you can set `CLAUDE_PLUGIN_ROOT` with Windows paths and they will be automatically converted:
 


### PR DESCRIPTION
…ility

The scripts already normalize CLAUDE_PLUGIN_ROOT via init_plugin_root(), but the command prompts (prompt.md, create-prompt.md) were passing the unnormalized path directly to bash commands and tools. This caused issues on Windows where CLAUDE_PLUGIN_ROOT might contain backslashes or drive letters in Windows format.

Changes:
- prompt.md: Normalize path using utils.sh before invoking scripts
- create-prompt.md: Normalize path at start, use NORMALIZED_ROOT throughout
- test-integration.sh: Normalize CLAUDE_PLUGIN_ROOT at startup
- docs/migration.md: Document that both scripts and prompts normalize paths
- CHANGELOG.md: Document the fix

This ensures consistent path handling across all entry points (scripts and prompts) and completes the cross-platform path normalization feature.