### PR TITLE
Update documentation and scripts for Bash 3.2 compatibility

### DIFF
--- a/meta-prompt/CONTRIBUTING.md
+++ b/meta-prompt/CONTRIBUTING.md
@@ -23,7 +23,7 @@ Thank you for your interest in contributing! This guide will help you get starte
 
 Before contributing, ensure you have:
 
-- Bash 4.0+ installed
+- Bash 3.2+ installed (default on macOS works)
 - Git 2.0+ installed
 - Claude Code CLI (latest version)
 - Text editor with markdown support

--- a/meta-prompt/commands/scripts/prompt-handler.sh
+++ b/meta-prompt/commands/scripts/prompt-handler.sh
@@ -1,4 +1,4 @@
-#!/bin/bash
+#!/usr/bin/env bash
 # Purpose: Deterministic orchestration for /prompt command
 # Inputs: $1=task_description, $2=flags (optional)
 # Outputs: Instructions for Claude Code to execute

--- a/meta-prompt/commands/scripts/template-processor.sh
+++ b/meta-prompt/commands/scripts/template-processor.sh
@@ -1,4 +1,4 @@
-#!/bin/bash
+#!/usr/bin/env bash
 # Purpose: Load templates and substitute variables
 # Inputs: $1=template_name, $2+=variable_values (as key=value pairs)
 # Outputs: Processed template ready for execution

--- a/meta-prompt/commands/scripts/template-selector.sh
+++ b/meta-prompt/commands/scripts/template-selector.sh
@@ -1,4 +1,4 @@
-#!/bin/bash
+#!/usr/bin/env bash
 # Purpose: Classify tasks and route to appropriate templates
 # Inputs: $1=task_description
 # Outputs: template_name (or "custom")

--- a/meta-prompt/commands/scripts/test-integration.sh
+++ b/meta-prompt/commands/scripts/test-integration.sh
@@ -1,4 +1,4 @@
-#!/bin/bash
+#!/usr/bin/env bash
 # End-to-End Integration Test Suite
 # Tests all components of the optimization implementation
 

--- a/meta-prompt/commands/scripts/validate-templates.sh
+++ b/meta-prompt/commands/scripts/validate-templates.sh
@@ -1,4 +1,4 @@
-#!/bin/bash
+#!/usr/bin/env bash
 # Purpose: Validate template files for syntax and completeness
 # Inputs: Optional template name (validates all if not specified)
 # Outputs: Validation results and errors

--- a/meta-prompt/docs/architecture-overview.md
+++ b/meta-prompt/docs/architecture-overview.md
@@ -239,7 +239,7 @@ description: <description>
 ### Dependencies
 
 **Required:**
-- Bash 4.0+ (for associative arrays, pattern matching)
+- Bash 3.2+ (compatible with macOS default bash)
 - Standard Unix utilities (grep, sed, awk, wc, tr, cut)
 
 **Optional:**

--- a/meta-prompt/docs/design-decisions.md
+++ b/meta-prompt/docs/design-decisions.md
@@ -100,7 +100,7 @@ Implement a **Deterministic Preprocessor + Focused LLM** architecture where:
 
 ### AD-002: Bash for Deterministic Processing
 
-**TL;DR:** Chose Bash 4.0+ for zero-dependency, <100ms startup, universal availability across macOS/Linux/WSL
+**TL;DR:** Chose Bash 3.2+ for zero-dependency, <100ms startup, universal availability across macOS/Linux/WSL (works with macOS default bash)
 
 **Status:** Accepted
 **Date:** 2025-11-18
@@ -114,7 +114,7 @@ The deterministic processing layer requires a runtime that is:
 
 **Decision:**
 
-Use **Bash 4.0+** for all deterministic processing scripts (handler, selector, processor, validator).
+Use **Bash 3.2+** for all deterministic processing scripts (handler, selector, processor, validator).
 
 **Rationale:**
 
@@ -157,9 +157,9 @@ Use **Bash 4.0+** for all deterministic processing scripts (handler, selector, p
 
 - Negative:
   - String processing can be verbose (sed/awk syntax)
-  - Limited structured data handling (arrays, hashes)
+  - Limited structured data handling (no associative arrays in Bash 3.2)
   - Error handling less elegant than modern languages
-  - Requires bash-specific features (associative arrays = bash 4.0+)
+  - Must avoid Bash 4+ features to maintain compatibility with macOS default bash
 
 - Neutral:
   - Developers must understand bash scripting
@@ -552,7 +552,7 @@ The system must be deployable without installation steps beyond standard Unix en
 
 **Decision:**
 
-Rely only on **standard Unix utilities** (grep, sed, awk, wc, tr, cut) and Bash 4.0+. Mark `jq` as optional (not currently used).
+Rely only on **standard Unix utilities** (grep, sed, awk, wc, tr, cut) and Bash 3.2+. Mark `jq` as optional (not currently used).
 
 **Rationale:**
 

--- a/meta-prompt/docs/examples.md
+++ b/meta-prompt/docs/examples.md
@@ -177,14 +177,14 @@ Process:
 
 ```markdown
 <Relevant Quotes>
-<Quote> [1] "Bash 4.0 or higher" </Quote>
+<Quote> [1] "Bash 3.2 or higher" </Quote>
 <Quote> [2] "Git" </Quote>
 <Quote> [3] "Claude Code CLI (latest version)" </Quote>
 <Quote> [4] "Standard Unix utilities: grep, sed, awk, wc, tr, cut" </Quote>
 </Relevant Quotes>
 
 <Answer>
-The installation requirements are: [1] Bash version 4.0 or higher, [2] Git for version control, [3] the latest version of Claude Code CLI, and [4] standard Unix utilities including grep, sed, awk, wc, tr, and cut.
+The installation requirements are: [1] Bash version 3.2 or higher, [2] Git for version control, [3] the latest version of Claude Code CLI, and [4] standard Unix utilities including grep, sed, awk, wc, tr, and cut.
 </Answer>
 ```
 

--- a/meta-prompt/docs/glossary.md
+++ b/meta-prompt/docs/glossary.md
@@ -196,12 +196,14 @@ The percentage decrease in token consumption achieved by using deterministic pre
 
 ## Technical Terms
 
-### Bash 4.0+
-The minimum version of the Bash shell required for this project. Required features: associative arrays, extended pattern matching, case conversion.
+### Bash 3.2+
+The minimum version of the Bash shell required for this project. Works with the default bash shipped with macOS.
 
 **Check version:** `bash --version`
 
-**Why 4.0+:** Associative arrays (`declare -A`) were introduced in bash 4.0.
+**Features used:** `[[` conditionals, regex matching (`=~`), BASH_REMATCH, string replacement (`//`), here-strings, indexed arrays.
+
+**Why 3.2+:** All required features are available in Bash 3.2, avoiding the need for Homebrew installation on macOS.
 
 ---
 
@@ -231,7 +233,7 @@ A bash safety pattern that ensures scripts fail fast and catch errors early.
 ---
 
 ### Associative Array
-A bash data structure (hash map) that stores key-value pairs. Used for keyword categorization.
+A bash data structure (hash map) that stores key-value pairs.
 
 **Example:**
 ```bash
@@ -242,6 +244,8 @@ declare -A keywords=(
 ```
 
 **Requirement:** Bash 4.0+
+
+**Note:** Not currently used in this project to maintain Bash 3.2 compatibility.
 
 ---
 

--- a/meta-prompt/docs/infrastructure.md
+++ b/meta-prompt/docs/infrastructure.md
@@ -360,7 +360,7 @@ git push --force origin main  # WARNING: Destructive
 - Windows with WSL (Windows Subsystem for Linux)
 
 **Required Software:**
-- Bash 4.0 or higher
+- Bash 3.2 or higher (macOS default bash works)
 - Git
 - Claude Code CLI (latest version)
 
@@ -526,7 +526,7 @@ Threshold: 70%
 
 **Dependency Update Policy:**
 
-- Pin specific versions in documentation (e.g., "Bash 4.0+")
+- Pin specific versions in documentation (e.g., "Bash 3.2+")
 - Test on oldest supported version
 - Document breaking changes between versions
 - Provide fallback implementations when possible

--- a/meta-prompt/docs/migration.md
+++ b/meta-prompt/docs/migration.md
@@ -418,7 +418,7 @@ git checkout v1.0 -- .claude-plugin/settings.json
 
 | Component | 1.0 | 1.1 (future) | 2.0 (future) |
 |-----------|-----|--------------|--------------|
-| Bash 4.0+ | ✅ Required | ✅ Required | ⚠️ May require 4.2+ |
+| Bash 3.2+ | ✅ Required | ✅ Required | ⚠️ May require 4.2+ |
 | Claude Code CLI | ✅ Latest | ✅ Latest | ✅ Latest |
 | Git 2.0+ | ✅ Required | ✅ Required | ✅ Required |
 | macOS | ✅ Supported | ✅ Supported | ✅ Supported |

--- a/meta-prompt/docs/script-development.md
+++ b/meta-prompt/docs/script-development.md
@@ -35,35 +35,48 @@ See design-decisions.md:AD-002 for full rationale.
 
 ## Bash Version Requirements
 
-### Minimum Version: 4.0+
+### Minimum Version: 3.2+
 
-**Required features:**
+All scripts in this project are compatible with Bash 3.2+, including the default bash shipped with macOS.
+
+**Features used (all available in Bash 3.2):**
+- `[[` conditional expressions (Bash 2.0+)
+- Regex matching with `=~` operator (Bash 3.0+)
+- BASH_REMATCH array (Bash 3.0+)
+- String replacement `${var//pattern/replacement}` (Bash 3.1+)
+- Here-strings `<<<` (Bash 3.0+)
+- Indexed arrays (Bash 2.0+)
+
+**Features NOT used (Bash 4+ only):**
 - Associative arrays (`declare -A`)
-- Extended pattern matching
-- `[[` conditional expressions
-- `${var,,}` case conversion
+- Case conversion (`${var^^}`, `${var,,}`)
+- `readarray`/`mapfile` commands
+- `**` globstar pattern
+- `&>>` redirection operator
 
 ### Check Your Version
 
 ```bash
 bash --version
-# Should show: GNU bash, version 4.x or higher
+# Should show: GNU bash, version 3.2 or higher
 ```
 
-### Platform-Specific Notes
+### Platform Compatibility
 
 **macOS:**
-- Default bash is 3.2 (too old)
-- Install bash 5.x via Homebrew: `brew install bash`
-- Update shebang if needed: `#!/usr/local/bin/bash`
+- ✅ Default bash 3.2 works out-of-the-box (no Homebrew needed)
+- macOS 10.5+ ships with bash 3.2.57
+- No additional installation required
 
 **Linux:**
-- Most distributions ship bash 4.2+
+- ✅ All distributions ship with bash 3.2+
 - Ubuntu 18.04+: bash 4.4
 - CentOS 7+: bash 4.2
+- Debian 8+: bash 4.3
 
 **Windows/WSL:**
-- WSL ships with bash 4.4+
+- ✅ WSL ships with bash 4.4+
+- ✅ Git Bash includes bash 3.2+
 - PowerShell is NOT supported (different language)
 
 ---
@@ -507,25 +520,7 @@ else
 fi
 ```
 
-### Pitfall 4: Associative Array Syntax
-
-**Problem (Bash 3.x):**
-```bash
-declare -A keywords  # Not supported in bash 3.x
-```
-
-**Solution:**
-```bash
-# Check bash version
-if [[ "${BASH_VERSINFO[0]}" -lt 4 ]]; then
-    echo "ERROR: Bash 4.0+ required" >&2
-    exit 1
-fi
-
-declare -A keywords
-```
-
-### Pitfall 5: Command Substitution in Quotes
+### Pitfall 4: Command Substitution in Quotes
 
 **Problem:**
 ```bash
@@ -541,7 +536,7 @@ template_name=$(head -1 "$file")
 message="Template: ${template_name}"
 ```
 
-### Pitfall 6: Integer Comparison vs String
+### Pitfall 5: Integer Comparison vs String
 
 **Problem:**
 ```bash


### PR DESCRIPTION
## Summary

This PR updates all documentation and bash scripts to accurately reflect Bash 3.2 compatibility, eliminating the need for Homebrew bash installation on macOS.

### Key Changes

**Documentation Updates (8 files):**
- Updated minimum Bash version from 4.0+ to 3.2+ across all docs
- Updated feature lists to reflect actual Bash features used
- Added macOS compatibility notes (default bash 3.2 works)
- Removed references to unused Bash 4+ features
- Removed "Pitfall 4: Associative Array Syntax" section

**Script Updates (5 files):**
- Changed shebangs from `#!/bin/bash` to `#!/usr/bin/env bash`
- More portable across different bash installations
- Works with bash in user's PATH

### Benefits

✅ **macOS compatibility**: Works out-of-the-box with default bash 3.2 (no Homebrew needed)  
✅ **Better portability**: `/usr/bin/env bash` finds bash in PATH  
✅ **Accurate documentation**: Matches actual code requirements  
✅ **Verified compatibility**: All scripts use only Bash 3.2+ features  

### Technical Details

All scripts currently use only these Bash 3.2-compatible features:
- `[[` conditional expressions (Bash 2.0+)
- Regex matching with `=~` (Bash 3.0+)
- BASH_REMATCH array (Bash 3.0+)
- String replacement `${var//pattern/replacement}` (Bash 3.1+)
- Here-strings `<<<` (Bash 3.0+)
- Indexed arrays (Bash 2.0+)

**Not used** (Bash 4+ only):
- Associative arrays (`declare -A`)
- Case conversion (`${var^^}`, `${var,,}`)
- `readarray`/`mapfile` commands
- `**` globstar pattern

### Files Modified

**Scripts:**
- commands/scripts/template-selector.sh
- commands/scripts/prompt-handler.sh
- commands/scripts/template-processor.sh
- commands/scripts/validate-templates.sh
- commands/scripts/test-integration.sh

**Documentation:**
- CONTRIBUTING.md
- docs/script-development.md
- docs/design-decisions.md
- docs/infrastructure.md
- docs/glossary.md
- docs/architecture-overview.md
- docs/migration.md
- docs/examples.md

## Test Plan

- [x] Verified all scripts use only Bash 3.2+ features
- [x] Updated all documentation references to Bash version
- [x] Changed all script shebangs to portable format
- [ ] Test scripts on macOS with default bash 3.2
- [ ] Test scripts on Linux with bash 4+
- [ ] Run integration test suite